### PR TITLE
Add fixedWidth option to CustomButton

### DIFF
--- a/components/Constants.js
+++ b/components/Constants.js
@@ -11,3 +11,4 @@ export const SMALL_HORIZONTAL_MARGIN_BUTTON = '5px';
 export const BIG_MIN_HEIGHT_BUTTON = '75px';
 export const VBIG_MIN_HEIGHT_BUTTON = '150px';
 export const ONELINE_MAX_HEIGHT_PLAY_BUTTON = '75px';
+export const FIXED_TEXT_WIDTH_BUTTON = '200px';

--- a/components/CustomButton.js
+++ b/components/CustomButton.js
@@ -44,6 +44,10 @@ const Icon = styled.Image`
     bottom: 3%;
 `;
 
+const StandardTextContainer = styled.View`
+    align-items: center;
+`;
+
 const pickIconToDisplay = (categoryName, isDisable) => {
     switch (categoryName) {
         case CATEGORY.FAVORITES:
@@ -110,6 +114,8 @@ const CustomButton = ({
     onPress,
     displayIcon,
     horizontalMargin,
+    isAllCap,
+    fixedTextWidth,
     ...others
 }) => {
     return (
@@ -121,7 +127,11 @@ const CustomButton = ({
             minHeight={minHeight}
             horizontalMargin={horizontalMargin}
         >
-            <StandardText color={color}>{text}</StandardText>
+            <StandardTextContainer>
+                <StandardText color={color} fixedTextWidth={fixedTextWidth}>
+                    {isAllCap ? text.toUpperCase() : text}
+                </StandardText>
+            </StandardTextContainer>
 
             {warningText && (
                 <WarningText categoryName={color}>{warningText}</WarningText>

--- a/components/CustomTextbox.js
+++ b/components/CustomTextbox.js
@@ -25,11 +25,12 @@ const SmallerTextboxContainer = styled.View`
 export const StandardText = styled.Text`
     font-family: Avenir;
     font-style: normal;
-    font-weight: 500;
-    font-size: 23px;
-    line-height: 41px;
-    text-align: center;
     font-weight: 900;
+    font-size: 23px;
+    line-height: 32px;
+    text-align: center;
+    flex-shrink: 1;
+    width: ${props => `${props.fixedTextWidth}`};
     color: ${props =>
         props.color === 'my bright future'
             ? props.theme.colors['CMDPink']

--- a/pages/Play.js
+++ b/pages/Play.js
@@ -3,7 +3,8 @@ import { StatusBar } from 'expo-status-bar';
 import React, { useState, useEffect } from 'react';
 import {
     BIG_MIN_HEIGHT_BUTTON,
-    ONELINE_MAX_HEIGHT_PLAY_BUTTON
+    ONELINE_MAX_HEIGHT_PLAY_BUTTON,
+    FIXED_TEXT_WIDTH_BUTTON
 } from '../components/Constants.js';
 import CustomButton from '../components/CustomButton.js';
 import Card from '../components/Card.js';
@@ -46,6 +47,8 @@ export const Play = ({ navigation }) => {
                     displayIcon={true}
                     maxHeight={ONELINE_MAX_HEIGHT_PLAY_BUTTON}
                     disabled={lengthOfCardLeft === 0}
+                    isAllCap={true}
+                    fixedTextWidth={FIXED_TEXT_WIDTH_BUTTON}
                     warningText={
                         lengthOfCardLeft <= 3
                             ? `${lengthOfCardLeft} ${


### PR DESCRIPTION
Change list:

- Add an optional `fixedTextWidth` option to CustomButton to custom the line width of the text.
- Add a constant to the width of the button on the Play page
- Add an `isAllCap` option to the CustomButton to capitalize the button text


![image](https://user-images.githubusercontent.com/55929961/132987608-6f44af53-f301-454f-b6e9-30837ae7ca09.png)
