### PR TITLE
Refactor parent guide info page

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
 import { CardTextbox } from './CustomTextbox.js';
 import CustomButton from './CustomButton.js';
-import { BIG_MIN_HEIGHT_BUTTON, SMALL_HORIZONTAL_MARGIN_BUTTON } from './Constants.js';
+import {
+    SMALL_HORIZONTAL_MARGIN_BUTTON,
+    DONE_HORIZONTAL_MARGIN_BUTTON
+} from './Constants.js';
 import styled from 'styled-components/native';
-import { ScrollView, View } from 'react-native';
+import { View } from 'react-native';
 import { Roboto } from '@expo-google-fonts/inter';
 
 const CardTitleTextboxContainer = styled.View`
@@ -30,7 +33,9 @@ const CardTitleText = styled.Text`
 
 const CardTitle = ({ text, color }) => (
     <CardTitleTextboxContainer color={color}>
-        <CardTitleText color={color} style={{ fontFamily: Roboto }}>{text}</CardTitleText>
+        <CardTitleText color={color} style={{ fontFamily: Roboto }}>
+            {text}
+        </CardTitleText>
     </CardTitleTextboxContainer>
 );
 
@@ -62,7 +67,11 @@ const Card = ({
     const [followUp] = useState(
         <Card
             category={category}
-            question={question['Follow Up'] ? question['Follow Up'].split('|') : question['Follow Up']}
+            question={
+                question['Follow Up']
+                    ? question['Follow Up'].split('|')
+                    : question['Follow Up']
+            }
             color={color}
             hasFollowUp={false}
             setModalVisible={setModalVisible}
@@ -87,9 +96,11 @@ const Card = ({
                                 text="DONE"
                                 color={color}
                                 onPress={() => setModalVisible(false)}
-                                horizontalMargin={SMALL_HORIZONTAL_MARGIN_BUTTON}
-                                height='100%'
-                                marginVertical='0'
+                                horizontalMargin={
+                                    SMALL_HORIZONTAL_MARGIN_BUTTON
+                                }
+                                height="100%"
+                                marginVertical="0"
                                 fontWeight="500"
                                 fontSize={28}
                             ></CustomButton>
@@ -97,9 +108,11 @@ const Card = ({
                                 text="FOLLOW UP"
                                 color={color}
                                 onPress={() => setOptions(followUp)}
-                                horizontalMargin={SMALL_HORIZONTAL_MARGIN_BUTTON}
-                                height='100%'
-                                marginVertical='0'
+                                horizontalMargin={
+                                    SMALL_HORIZONTAL_MARGIN_BUTTON
+                                }
+                                height="100%"
+                                marginVertical="0"
                                 fontWeight="500"
                                 fontSize={28}
                             ></CustomButton>
@@ -109,18 +122,18 @@ const Card = ({
                             text="DONE"
                             color={color}
                             onPress={() => setModalVisible(false)}
-                            horizontalMargin='20px'
-                            fontWeight='500'
+                            horizontalMargin={DONE_HORIZONTAL_MARGIN_BUTTON}
+                            fontWeight="500"
                             fontSize={28}
                             lineHeight={38.25}
-                            height='100%'
-                            marginVertical='0'
+                            height="100%"
+                            marginVertical="0"
                         ></CustomButton>
                     )}
                 </View>
                 <View style={{ height: '1.5%' }}></View>
             </View>
-        </CardView >
+        </CardView>
     );
 };
 

--- a/components/Constants.js
+++ b/components/Constants.js
@@ -7,7 +7,14 @@ export const CATEGORY = {
     BRIGHTFUTURE: 'my bright future'
 };
 
+export const ICONTYPE = {
+    PLAYPAGE: 1,
+    PARENTGUIDEPAGE: 2,
+    CARDPAGE: 3
+};
+
 export const SMALL_HORIZONTAL_MARGIN_BUTTON = '5px';
 export const BIG_MIN_HEIGHT_BUTTON = '75px';
 export const VBIG_MIN_HEIGHT_BUTTON = '150px';
 export const ONELINE_MAX_HEIGHT_PLAY_BUTTON = '75px';
+export const DONE_HORIZONTAL_MARGIN_BUTTON = '20px';

--- a/components/CustomButton.js
+++ b/components/CustomButton.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components/native';
 import { StandardText } from './CustomTextbox.js';
 import { CATEGORY } from './Constants.js';
+import { pickIconToDisplay } from './Icon.js';
 
 const ButtonContainer = styled.TouchableOpacity`
     align-self: stretch;
@@ -36,71 +37,6 @@ const WarningText = styled.Text`
     font-weight: 600;
 `;
 
-const Icon = styled.Image`
-    position: absolute;
-    width: 24px;
-    height: 24px;
-    right: 3%;
-    bottom: 3%;
-`;
-
-const pickIconToDisplay = (categoryName, isDisable) => {
-    switch (categoryName) {
-        case CATEGORY.FAVORITES:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-favorites_filled.png')}
-                />
-            );
-
-        case CATEGORY.DANCECHALLENGE:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
-                />
-            );
-
-        case CATEGORY.ALLABOUTME:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
-                />
-            );
-
-        case CATEGORY.INNERME:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-innerme_filled.png')}
-                />
-            );
-
-        case CATEGORY.WHATWOULDYOURDO:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-whatwouldyoudo_filled.png')}
-                />
-            );
-
-        case CATEGORY.BRIGHTFUTURE:
-            if (isDisable) {
-                return (
-                    <Icon
-                        source={require('../assets/genconnect_icon-brightfuture_filled.png')}
-                    />
-                );
-            } else {
-                return (
-                    <Icon
-                        source={require('../assets/genconnect_icon-brightfuture_pink_outline.png')}
-                    />
-                );
-            }
-
-        default:
-            return null;
-    }
-};
-
 const CustomButton = ({
     text,
     color,
@@ -126,7 +62,7 @@ const CustomButton = ({
             {warningText && (
                 <WarningText categoryName={color}>{warningText}</WarningText>
             )}
-            {displayIcon && pickIconToDisplay(color, others.disabled)}
+            {displayIcon && pickIconToDisplay(color, others.disabled, true)}
         </ButtonContainer>
     );
 };

--- a/components/CustomButton.js
+++ b/components/CustomButton.js
@@ -1,14 +1,17 @@
 import React from 'react';
 import styled from 'styled-components/native';
 import { StandardText } from './CustomTextbox.js';
-import { CATEGORY } from './Constants.js';
+import { CATEGORY, ICONTYPE } from './Constants.js';
 import { pickIconToDisplay } from './Icon.js';
 
 const ButtonContainer = styled.TouchableOpacity`
     align-self: stretch;
     justify-content: center;
     border-radius: 20px;
-    ${props => (props.marginVertical ? `margin-vertical: ${props.marginVertical}};` : 'margin-vertical: 10px;')};
+    ${props =>
+        props.marginVertical
+            ? `margin-vertical: ${props.marginVertical}};`
+            : 'margin-vertical: 10px;'};
     flex-grow: 100;
 
     background-color: ${props =>
@@ -65,12 +68,22 @@ const CustomButton = ({
             horizontalMargin={horizontalMargin}
             marginVertical={marginVertical}
         >
-            <StandardText color={color} style={{ fontWeight: fontWeight ? fontWeight : "900", fontSize: fontSize ? fontSize : 23, lineHeight: lineHeight ? lineHeight : 41 }}>{text}</StandardText>
+            <StandardText
+                color={color}
+                style={{
+                    fontWeight: fontWeight ? fontWeight : '900',
+                    fontSize: fontSize ? fontSize : 23,
+                    lineHeight: lineHeight ? lineHeight : 41
+                }}
+            >
+                {text}
+            </StandardText>
 
             {warningText && (
                 <WarningText categoryName={color}>{warningText}</WarningText>
             )}
-            {displayIcon && pickIconToDisplay(color, others.disabled, true)}
+            {displayIcon &&
+                pickIconToDisplay(color, ICONTYPE.PLAYPAGE, others.disabled)}
         </ButtonContainer>
     );
 };

--- a/components/CustomTextbox.js
+++ b/components/CustomTextbox.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/native';
 import { pickIconToDisplay } from './Icon';
-import { CATEGORY } from './Constants.js';
+import { ICONTYPE } from './Constants.js';
 
 const TextboxContainer = styled.View`
     background-color: ${props =>
@@ -106,65 +106,6 @@ export const QuestionTextbox = ({ text, color }) => (
     </TextboxContainer>
 );
 
-const Icon = styled.Image`
-    width: 130px;
-    height: 130px;
-    align-self: center;
-`;
-
-const pickIconToDisplay = categoryName => {
-    switch (categoryName) {
-        case CATEGORY.FAVORITES:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-favorites_filled.png')}
-                />
-            );
-
-        case CATEGORY.DANCECHALLENGE:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
-                />
-            );
-
-        case CATEGORY.ALLABOUTME:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
-                />
-            );
-
-        case CATEGORY.INNERME:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-innerme_filled.png')}
-                />
-            );
-
-        case CATEGORY.WHATWOULDYOURDO:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-whatwouldyoudo_filled.png')}
-                />
-            );
-
-        case CATEGORY.BRIGHTFUTURE:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-brightfuture_pink_outline.png')}
-                />
-            );
-
-        default:
-            return (
-                <Icon
-                    source={require('../assets/genconnect_icon-brightfuture_pink_outline.png')}
-                />
-            );
-    }
-};
-
 export const CardTextbox = ({ textList, color }) => {
     const displayText = textList.map((text, index) => (
         <StandardText
@@ -178,7 +119,7 @@ export const CardTextbox = ({ textList, color }) => {
 
     return (
         <CardContainer length={textList.length} color={color} isScroll={true}>
-            {pickIconToDisplay(color)}
+            {pickIconToDisplay(color, ICONTYPE.CARDPAGE)}
             {displayText}
         </CardContainer>
     );
@@ -253,7 +194,7 @@ export const InterpretationTextbox = ({
             isScroll={isScroll}
         >
             {displayText}
-            {pickIconToDisplay(color, false, false)}
+            {pickIconToDisplay(color, ICONTYPE.PARENTGUIDEPAGE, false)}
         </ParentGuideContainer>
     );
 };

--- a/components/CustomTextbox.js
+++ b/components/CustomTextbox.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Text, View } from 'react-native';
 import styled from 'styled-components/native';
+import { pickIconToDisplay } from './Icon';
 
 const TextboxContainer = styled.View`
     background-color: ${props =>
@@ -25,7 +25,6 @@ const SmallerTextboxContainer = styled.View`
 export const StandardText = styled.Text`
     font-family: Avenir;
     font-style: normal;
-    font-weight: 500;
     font-size: 23px;
     line-height: 41px;
     text-align: center;
@@ -34,68 +33,6 @@ export const StandardText = styled.Text`
         props.color === 'my bright future'
             ? props.theme.colors['CMDPink']
             : 'white'};
-`;
-
-export const CategoryText = styled(StandardText)`
-    font-size: 23px;
-    line-height: 32px;
-    font-weight: 900;
-    width: 191px;
-    flex-shrink: 1;
-`;
-
-export const GroupText = styled(StandardText)`
-    font-size: 20px;
-    line-height: 27.32px;
-    font-weight: 800;
-    width: 290px;
-    flex-shrink: 1;
-`;
-
-export const CategoryQuestionText = styled(StandardText)`
-    font-size: 23px;
-    line-height: 31.42px;
-    font-weight: 800;
-    flex-shrink: 1;
-`;
-
-export const SmallerStandardText = styled.Text`
-    font-family: Avenir;
-    font-style: normal;
-    font-weight: 500;
-    font-size: 20px;
-    line-height: 41px;
-    text-align: center;
-
-    color: #ffffff;
-
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
-`;
-
-export const BoldText = styled.Text`
-    font-family: Avenir;
-    font-style: normal;
-    font-weight: 900;
-    font-size: 30px;
-    line-height: 41px;
-    text-align: center;
-
-    color: #ffffff;
-
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
-`;
-
-export const SmallerBoldText = styled.Text`
-    font-family: Avenir;
-    font-style: normal;
-    font-weight: 900;
-    font-size: 25px;
-    line-height: 41px;
-    text-align: center;
-
-    color: #ffffff;
-
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
 `;
 
 const CardContainer = styled.View`
@@ -131,15 +68,30 @@ const ParentGuideContainer = styled.View`
     border-radius: 20px;
     margin-top: 10px;
     margin-horizontal: 20px;
-    justify-content: ${props =>
-        props.length > 1
-            ? props.length == 2
-                ? 'space-around'
-                : 'space-between'
-            : 'center'};
-    padding: ${props =>
-        props.length > 1 ? '50px 40px 50px 40px' : '40px 40px'};
+    padding: 28px
     min-height: ${props => (props.isScroll ? '500px' : '70%')};
+`;
+
+const QuestionText = styled(StandardText)`
+    font-size: 25px;
+`;
+
+const HeadingText = styled(StandardText)`
+    font-size: 20px;
+    font-weight: 800;
+    line-height: 25px;
+`;
+
+const SubHeadingText = styled(StandardText)`
+    font-size: 20px;
+    font-weight: 800;
+    line-height: 25px;
+`;
+
+const ContentText = styled(StandardText)`
+    font-size: 20px;
+    font-weight: 400;
+    line-height: 25px;
 `;
 
 export const StandardTextbox = ({ text, color }) => (
@@ -148,10 +100,10 @@ export const StandardTextbox = ({ text, color }) => (
     </TextboxContainer>
 );
 
-export const SmallerStandardTextbox = ({ text, color }) => (
-    <SmallerTextboxContainer color={color}>
-        <SmallerStandardText>{text}</SmallerStandardText>
-    </SmallerTextboxContainer>
+export const QuestionTextbox = ({ text, color }) => (
+    <TextboxContainer color={color}>
+        <QuestionText color={color}>{text}</QuestionText>
+    </TextboxContainer>
 );
 
 export const CardTextbox = ({ textList, color }) => {
@@ -191,7 +143,7 @@ const TextBoarder = styled.View`
     margin-bottom: 15px;
 `;
 
-export const InterpretationTextBox = ({
+export const InterpretationTextbox = ({
     groupText,
     interpretationText,
     color,
@@ -201,7 +153,7 @@ export const InterpretationTextBox = ({
     let index = 0;
     displayText.push(
         <TextBoarder key={index++}>
-            <SmallerBoldText>{'INTERPRETATIONS'}</SmallerBoldText>
+            <HeadingText color={color}>{'INTERPRETATIONS'}</HeadingText>
         </TextBoarder>
     );
 
@@ -216,7 +168,7 @@ export const InterpretationTextBox = ({
         if (text != '') {
             displayText.push(
                 <TextBoarder key={index++}>
-                    <SmallerStandardText>{text}</SmallerStandardText>
+                    <SubHeadingText color={color}>{text}</SubHeadingText>
                 </TextBoarder>
             );
         }
@@ -225,7 +177,7 @@ export const InterpretationTextBox = ({
         if (text != '') {
             displayText.push(
                 <TextBoarder key={index++}>
-                    <SmallerStandardText>{text}</SmallerStandardText>
+                    <ContentText color={color}>{text}</ContentText>
                 </TextBoarder>
             );
         }
@@ -237,6 +189,7 @@ export const InterpretationTextBox = ({
             isScroll={isScroll}
         >
             {displayText}
+            {pickIconToDisplay(color, false, false)}
         </ParentGuideContainer>
     );
 };

--- a/components/Icon.js
+++ b/components/Icon.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import styled from 'styled-components/native';
+import { CATEGORY } from './Constants.js';
+
+const IconPlay = styled.Image`
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    right: 3%;
+    bottom: 3%;
+`;
+
+const IconParentGuide = styled.Image`
+    position: absolute;
+    width: 35px;
+    height: 35px;
+    right: 18px;
+    top: 18px;
+`;
+
+export const pickIconToDisplay = (categoryName, isDisable, isPlay) => {
+    switch (categoryName) {
+        case CATEGORY.FAVORITES:
+            return isPlay ? (
+                <IconPlay
+                    source={require('../assets/genconnect_icon-favorites_filled.png')}
+                />
+            ) : (
+                <IconParentGuide
+                    source={require('../assets/genconnect_icon-favorites_filled.png')}
+                />
+            );
+
+        case CATEGORY.DANCECHALLENGE:
+            return isPlay ? (
+                <IconPlay
+                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
+                />
+            ) : (
+                <IconParentGuide
+                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
+                />
+            );
+
+        case CATEGORY.ALLABOUTME:
+            return isPlay ? (
+                <IconPlay
+                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
+                />
+            ) : (
+                <IconParentGuide
+                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
+                />
+            );
+
+        case CATEGORY.INNERME:
+            return isPlay ? (
+                <IconPlay
+                    source={require('../assets/genconnect_icon-innerme_filled.png')}
+                />
+            ) : (
+                <IconParentGuide
+                    source={require('../assets/genconnect_icon-innerme_filled.png')}
+                />
+            );
+
+        case CATEGORY.WHATWOULDYOURDO:
+            return isPlay ? (
+                <IconPlay
+                    source={require('../assets/genconnect_icon-whatwouldyoudo_filled.png')}
+                />
+            ) : (
+                <IconParentGuide
+                    source={require('../assets/genconnect_icon-whatwouldyoudo_filled.png')}
+                />
+            );
+
+        case CATEGORY.BRIGHTFUTURE:
+            if (isDisable) {
+                return isPlay ? (
+                    <IconPlay
+                        source={require('../assets/genconnect_icon-brightfuture_filled.png')}
+                    />
+                ) : (
+                    <IconParentGuide
+                        source={require('../assets/genconnect_icon-brightfuture_filled.png')}
+                    />
+                );
+            } else {
+                return isPlay ? (
+                    <IconPlay
+                        source={require('../assets/genconnect_icon-brightfuture_pink_outline.png')}
+                    />
+                ) : (
+                    <IconParentGuide
+                        source={require('../assets/genconnect_icon-brightfuture_pink_outline.png')}
+                    />
+                );
+            }
+
+        default:
+            return null;
+    }
+};

--- a/components/Icon.js
+++ b/components/Icon.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components/native';
-import { CATEGORY } from './Constants.js';
+import { CATEGORY, ICONTYPE } from './Constants.js';
 
 const IconPlay = styled.Image`
     position: absolute;
@@ -18,84 +18,167 @@ const IconParentGuide = styled.Image`
     top: 18px;
 `;
 
-export const pickIconToDisplay = (categoryName, isDisable, isPlay) => {
+const IconCard = styled.Image`
+    width: 130px;
+    height: 130px;
+    align-self: center;
+`;
+
+export const pickIconToDisplay = (categoryName, iconType, isDisable) => {
     switch (categoryName) {
         case CATEGORY.FAVORITES:
-            return isPlay ? (
-                <IconPlay
-                    source={require('../assets/genconnect_icon-favorites_filled.png')}
-                />
-            ) : (
-                <IconParentGuide
-                    source={require('../assets/genconnect_icon-favorites_filled.png')}
-                />
-            );
-
+            switch (iconType) {
+                case ICONTYPE.PLAYPAGE:
+                    return (
+                        <IconPlay
+                            source={require('../assets/genconnect_icon-favorites_filled.png')}
+                        />
+                    );
+                case ICONTYPE.PARENTGUIDEPAGE:
+                    return (
+                        <IconParentGuide
+                            source={require('../assets/genconnect_icon-favorites_filled.png')}
+                        />
+                    );
+                case ICONTYPE.CARDPAGE:
+                    return (
+                        <IconCard
+                            source={require('../assets/genconnect_icon-favorites_filled.png')}
+                        />
+                    );
+                default:
+                    return null;
+            }
         case CATEGORY.DANCECHALLENGE:
-            return isPlay ? (
-                <IconPlay
-                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
-                />
-            ) : (
-                <IconParentGuide
-                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
-                />
-            );
+            switch (iconType) {
+                case ICONTYPE.PLAYPAGE:
+                    return (
+                        <IconPlay
+                            source={require('../assets/genconnect_icon-allaboutme_filled.png')}
+                        />
+                    );
+                case ICONTYPE.PARENTGUIDEPAGE:
+                    return (
+                        <IconParentGuide
+                            source={require('../assets/genconnect_icon-allaboutme_filled.png')}
+                        />
+                    );
+                case ICONTYPE.CARDPAGE:
+                    return (
+                        <IconCard
+                            source={require('../assets/genconnect_icon-allaboutme_filled.png')}
+                        />
+                    );
+                default:
+                    return null;
+            }
 
         case CATEGORY.ALLABOUTME:
-            return isPlay ? (
-                <IconPlay
-                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
-                />
-            ) : (
-                <IconParentGuide
-                    source={require('../assets/genconnect_icon-allaboutme_filled.png')}
-                />
-            );
+            switch (iconType) {
+                case ICONTYPE.PLAYPAGE:
+                    return (
+                        <IconPlay
+                            source={require('../assets/genconnect_icon-allaboutme_filled.png')}
+                        />
+                    );
+                case ICONTYPE.PARENTGUIDEPAGE:
+                    return (
+                        <IconParentGuide
+                            source={require('../assets/genconnect_icon-allaboutme_filled.png')}
+                        />
+                    );
+                case ICONTYPE.CARDPAGE:
+                    return (
+                        <IconCard
+                            source={require('../assets/genconnect_icon-allaboutme_filled.png')}
+                        />
+                    );
+                default:
+                    return null;
+            }
 
         case CATEGORY.INNERME:
-            return isPlay ? (
-                <IconPlay
-                    source={require('../assets/genconnect_icon-innerme_filled.png')}
-                />
-            ) : (
-                <IconParentGuide
-                    source={require('../assets/genconnect_icon-innerme_filled.png')}
-                />
-            );
+            switch (iconType) {
+                case ICONTYPE.PLAYPAGE:
+                    return (
+                        <IconPlay
+                            source={require('../assets/genconnect_icon-innerme_filled.png')}
+                        />
+                    );
+                case ICONTYPE.PARENTGUIDEPAGE:
+                    return (
+                        <IconParentGuide
+                            source={require('../assets/genconnect_icon-innerme_filled.png')}
+                        />
+                    );
+                case ICONTYPE.CARDPAGE:
+                    return (
+                        <IconCard
+                            source={require('../assets/genconnect_icon-innerme_filled.png')}
+                        />
+                    );
+                default:
+                    return null;
+            }
 
         case CATEGORY.WHATWOULDYOURDO:
-            return isPlay ? (
-                <IconPlay
-                    source={require('../assets/genconnect_icon-whatwouldyoudo_filled.png')}
-                />
-            ) : (
-                <IconParentGuide
-                    source={require('../assets/genconnect_icon-whatwouldyoudo_filled.png')}
-                />
-            );
+            switch (iconType) {
+                case ICONTYPE.PLAYPAGE:
+                    return (
+                        <IconPlay
+                            source={require('../assets/genconnect_icon-whatwouldyoudo_filled.png')}
+                        />
+                    );
+                case ICONTYPE.PARENTGUIDEPAGE:
+                    return (
+                        <IconParentGuide
+                            source={require('../assets/genconnect_icon-whatwouldyoudo_filled.png')}
+                        />
+                    );
+                case ICONTYPE.CARDPAGE:
+                    return (
+                        <IconCard
+                            source={require('../assets/genconnect_icon-whatwouldyoudo_filled.png')}
+                        />
+                    );
+                default:
+                    return null;
+            }
 
         case CATEGORY.BRIGHTFUTURE:
-            if (isDisable) {
-                return isPlay ? (
-                    <IconPlay
-                        source={require('../assets/genconnect_icon-brightfuture_filled.png')}
-                    />
-                ) : (
-                    <IconParentGuide
-                        source={require('../assets/genconnect_icon-brightfuture_filled.png')}
-                    />
-                );
-            } else {
-                return isPlay ? (
-                    <IconPlay
-                        source={require('../assets/genconnect_icon-brightfuture_pink_outline.png')}
-                    />
-                ) : (
-                    <IconParentGuide
-                        source={require('../assets/genconnect_icon-brightfuture_pink_outline.png')}
-                    />
-                );
+            switch (iconType) {
+                case ICONTYPE.PLAYPAGE:
+                    return isDisable ? (
+                        <IconPlay
+                            source={require('../assets/genconnect_icon-brightfuture_filled.png')}
+                        />
+                    ) : (
+                        <IconPlay
+                            source={require('../assets/genconnect_icon-brightfuture_pink_outline.png')}
+                        />
+                    );
+                case ICONTYPE.PARENTGUIDEPAGE:
+                    return isDisable ? (
+                        <IconParentGuide
+                            source={require('../assets/genconnect_icon-brightfuture_filled.png')}
+                        />
+                    ) : (
+                        <IconParentGuide
+                            source={require('../assets/genconnect_icon-brightfuture_pink_outline.png')}
+                        />
+                    );
+                case ICONTYPE.CARDPAGE:
+                    return isDisable ? (
+                        <IconCard
+                            source={require('../assets/genconnect_icon-brightfuture_filled.png')}
+                        />
+                    ) : (
+                        <IconCard
+                            source={require('../assets/genconnect_icon-brightfuture_pink_outline.png')}
+                        />
+                    );
+                default:
+                    return null;
             }
 
         default:

--- a/pages/ParentGuide.js
+++ b/pages/ParentGuide.js
@@ -415,7 +415,7 @@ export const ParentGuideInformation = ({ route, navigation }) => {
                         color={color}
                     ></InterpretationTextbox>
                     <CustomButton
-                        text="done"
+                        text="DONE"
                         color={color}
                         minHeight={BIG_MIN_HEIGHT_BUTTON}
                         onPress={() => navigation.pop()}

--- a/pages/ParentGuide.js
+++ b/pages/ParentGuide.js
@@ -12,8 +12,8 @@ import {
 } from '../components/StyledView';
 import {
     StandardTextbox,
-    InterpretationTextBox,
-    SmallerStandardTextbox
+    QuestionTextbox,
+    InterpretationTextbox
 } from '../components/CustomTextbox';
 import { View } from 'react-native';
 import GeometryBackground from '../components/GeometryBackground';
@@ -400,20 +400,20 @@ export const ParentGuideInformation = ({ route, navigation }) => {
             >
                 <InformationContainer>
                     <StandardTextbox
-                        text={category.toLowerCase()}
+                        text={category.toUpperCase()}
                         color={color}
                     ></StandardTextbox>
                     <TextContainerParentGuide>
-                        <SmallerStandardTextbox
-                            text={question.toLowerCase()}
+                        <QuestionTextbox
+                            text={question.toUpperCase()}
                             color={color}
-                        ></SmallerStandardTextbox>
+                        ></QuestionTextbox>
                     </TextContainerParentGuide>
-                    <InterpretationTextBox
+                    <InterpretationTextbox
                         interpretationText={interpretation}
                         groupText={group}
                         color={color}
-                    ></InterpretationTextBox>
+                    ></InterpretationTextbox>
                     <CustomButton
                         text="done"
                         color={color}


### PR DESCRIPTION
Change list:
- Add icon to ParentGuide info page
- Change text styling of the heading, subheading, and the card
  - The card now consists of `heading` `subheading` and `content` where content can be as many strings as possible

Note: the size of the text is a bit bigger than the design cause it looks way too small on the big screen. The design's font size is 18px. I made it 20. The icon size on the design was 29x29. I made it 35x35

![image](https://user-images.githubusercontent.com/55929961/132989736-d69de7a8-3744-43ab-8da1-18ad60fdb44a.png)
![image](https://user-images.githubusercontent.com/55929961/132989745-009ef300-06f9-48a4-83de-cc88aee11617.png)
![image](https://user-images.githubusercontent.com/55929961/132989762-5a6d4f8c-2886-4bf2-a5f3-315836f0bef9.png)
